### PR TITLE
[bugfix] Set primaryKey type to string in model User

### DIFF
--- a/piswap/app/User.php
+++ b/piswap/app/User.php
@@ -10,17 +10,16 @@ class User extends Authenticatable
 {
     use Notifiable;
 
-    protected $primaryKey = 'email';
     public $table = "users";
+
+    protected $primaryKey = 'email';
+    protected $keyType = 'string';
+    public $incrementing = false;
     public $timestamps = false;
 
     protected $fillable = [
         'name', 'surname', 'email', 'role', 'address', 'telephone', 'active', 'password'
     ];
-
-    protected $casts = [
-         'address' => 'json',
-     ];
 
     public function borrows()
     {


### PR DESCRIPTION
As default, Laravel assumes that the primary key is an integer type.
This PR fixes the authentication problem.